### PR TITLE
3902 bug format selection fg note

### DIFF
--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -5,14 +5,17 @@ import { ALLOWED_ATTR } from '../constants'
 import * as selection from '../device/selection'
 import getThoughtById from '../selectors/getThoughtById'
 import pathToThought from '../selectors/pathToThought'
+import resolveNotePath from '../selectors/resolveNotePath'
 import simplifyPath from '../selectors/simplifyPath'
 import themeColors from '../selectors/themeColors'
 import { updateCommandState } from '../stores/commandStateStore'
 import suppressFocusStore from '../stores/suppressFocus'
 import head from '../util/head'
+import noteValue from '../util/noteValue'
 import rgbToHex from '../util/rgbToHex'
 import strip from '../util/strip'
 import { editThoughtActionCreator as editThought } from './editThought'
+import { setDescendantActionCreator as setDescendant } from './setDescendant'
 
 /** Format the browser selection or cursor thought as bold, italic, strikethrough, underline. */
 export const formatSelectionActionCreator =
@@ -40,7 +43,10 @@ export const formatSelectionActionCreator =
       (selection.text()?.length === 0 && strip(thought.value).length !== 0) ||
       selection.text()?.length === strip(thought.value).length
     ) {
-      const hasCustomBackgroundColor = /background-color\s*:\s*[^;]+;?/.test(thought.value)
+      // Check the value of the note or thought for a custom background color (#3901)
+      const hasCustomBackgroundColor = /background-color\s*:\s*[^;]+;?/.test(
+        state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
+      )
       const savedSelection = selection.save()
       // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
       selection.select(contentEditable)
@@ -100,29 +106,42 @@ export const formatSelectionActionCreator =
           const state = getState()
           if (!state.cursor) return
 
-          const thought = getThoughtById(state, head(state.cursor))
-          if (!thought) return
-          const simplePath = simplifyPath(state, state.cursor)
+          // Could be formatting either a thought or a note (#3901)
+          const value = state.noteFocus
+            ? noteValue(state, state.cursor)
+            : getThoughtById(state, head(state.cursor))?.value
+          if (!value) return
+
+          const path = state.noteFocus ? resolveNotePath(state, state.cursor) : state.cursor
+          if (!path) return
+
           const styleAttrPattern = /style\s*=\s*["'][^"']*["']/gi
           const tagWithoutStylePattern = /<(span|font)(\s[^>]*)?>/gi
 
           //Replace style attributes based on the conditions
-          const styleRemovedThought = thought.value.replace(styleAttrPattern, match => {
+          const styleRemovedThought = value.replace(styleAttrPattern, match => {
             if (shouldRemoveStyle(match)) return ''
             return match
           })
           const tagsToRemove = collectTagsWithoutAttributes(styleRemovedThought, tagWithoutStylePattern)
           const newValue = removeTags(styleRemovedThought, tagsToRemove)
-          if (newValue !== thought.value)
+
+          // Overwrite the value of the thought or note with the stripped value in order to remove background highlighting (#3901)
+          if (newValue !== value)
             dispatch(
-              editThought({
-                cursorOffset: selection.offsetThought() ?? undefined,
-                oldValue: thought.value,
-                newValue: newValue,
-                path: simplePath,
-                // force the ContentEditable to update
-                force: true,
-              }),
+              state.noteFocus
+                ? setDescendant({
+                    path,
+                    values: [newValue],
+                  })
+                : editThought({
+                    cursorOffset: selection.offsetThought() ?? undefined,
+                    oldValue: value,
+                    newValue: newValue,
+                    path: simplifyPath(state, path),
+                    // force the ContentEditable to update
+                    force: true,
+                  }),
             )
         })
       }

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -12,6 +12,7 @@ const colors = {
     darkgray: 'rgba(17, 17, 17, 1)', // #111111
     fg85: 'rgba(217, 217, 217, 1)', // #d9d9d9
     fg: 'rgba(255, 255, 255, 1)',
+    fgNote: 'rgba(255, 255, 255, 0.5)',
     fgOverlay10: 'rgba(255, 255, 255, 0.1)',
     fgOverlay20: 'rgba(255, 255, 255, 0.2)',
     fgOverlay30: 'rgba(255, 255, 255, 0.3)',
@@ -101,6 +102,7 @@ const colors = {
     darkgray: 'rgba(237, 237, 237, 1)', // #ededed
     fg85: 'rgba(39, 39, 39, 1)', // #272727
     fg: 'rgba(0, 0, 0, 1)',
+    fgNote: 'rgba(0, 0, 0, 0.5)',
     fgOverlay10: 'rgba(0, 0, 0, 0.1)',
     fgOverlay20: 'rgba(0, 0, 0, 0.2)',
     fgOverlay30: 'rgba(0, 0, 0, 0.3)',

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -91,12 +91,15 @@ const ColorSwatch: FC<{
     )
   })
 
+  //
+  const fgColor = useSelector(state => (state.noteFocus ? 'fgNote' : 'fg'))
+
   /** Toggles the text color to the clicked swatch. If the swatch is already selected, sets text color and background color back to default. */
   const toggleTextColor = () => {
     dispatch(
       formatSelection(
         'foreColor',
-        selected ? 'fg' : color || (backgroundColor && backgroundColor !== 'fg' ? 'black' : 'bg'),
+        selected ? fgColor : color || (backgroundColor && backgroundColor !== 'fg' ? 'black' : 'bg'),
       ),
     )
 

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -91,7 +91,7 @@ const ColorSwatch: FC<{
     )
   })
 
-  //
+  // Note is semi-transparent by default and its color must be reset to that rather than white, which is the fg color for thoughts. (#3902)
   const fgColor = useSelector(state => (state.noteFocus ? 'fgNote' : 'fg'))
 
   /** Toggles the text color to the clicked swatch. If the swatch is already selected, sets text color and background color back to default. */

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -248,3 +248,18 @@ it('Clicking on a formatting tag does not close color dropdown', async () => {
 
   expect(textColorSwatch).toBeTruthy()
 })
+
+it('Setting note foreground color should remove background color', async () => {
+  await paste(`
+    - a
+      - =note
+        - <font style="background-color: #FFFFFF" color="#000000">Note</font>
+  `)
+
+  await click('[aria-label="note-editable"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="text color swatches"] [aria-label="yellow"]')
+
+  const result = await page.evaluate(() => document.querySelector('[aria-label="note-editable"]')?.innerHTML)
+  expect(result).toBe('<font color="#ffd014">Note</font>')
+})


### PR DESCRIPTION
Fixes #3902, depends on #3901

This needs to wait until #4001 gets merged because I see that #3901 is affecting the end color of a note after following the repro steps.

I added a new `fgNote` color to `colors.config.ts` so that we can reset a note to its default semi-transparent grey color rather than the default white color for thoughts. `ColorPicker` checks `state.noteFocus` to determine which color to send to `formatSelection`. This could be handled inside of `formatSelection` if you would prefer. That could cause merge conflicts with #4001, but it turns out that this depends on that PR anyway.

I would have preferred to remove the color directly, but it seems that doing something like `document.execCommand('removeFormat')` removes all formatting, and there's no option to only remove specific formatting. It turns out that correctly setting the color to its default does remove the font tag from the thought or note, which is nice.

I also could have tried a post-processing approach similar to [backColor](https://github.com/ethan-james/em/blob/eb7d601b69ee2bb74a01fe2686cb578bb58b16e7/src/actions/formatSelection.ts#L71). It would be more verbose, but I think that I could make a copy of [shouldRemoveStyle](https://github.com/ethan-james/em/blob/eb7d601b69ee2bb74a01fe2686cb578bb58b16e7/src/actions/formatSelection.ts#L74) that does something like

```
const fgColor = state.noteFocus ? colors.fgNote : colors.fg
const isSameColor = elementColor && rgbToHex(elementColor) === rgbToHex(fgColor)
```

but that still requires adding to `colors.config.ts`.

TODO: add a Puppeteer test (component test will throw a warning: `document.execCommand is not implemented in JSDOM`